### PR TITLE
feat: Implement dark mode theme toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint"
   },

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -55,29 +55,29 @@ export default async function DashboardPage() {
       <h1 className="text-2xl font-bold mb-4">Painel</h1>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
-        <div className="bg-white p-4 rounded shadow">
+        <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
           <h2 className="text-xl font-semibold mb-2">Resumo</h2>
           <p>Receita Total: {formatCurrency(income)}</p>
           <p>Despesa Total: {formatCurrency(expense)}</p>
           <p>Saldo: {formatCurrency(income - expense)}</p>
         </div>
 
-        <div className="bg-white p-4 rounded shadow">
+        <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
           <h2 className="text-xl font-semibold mb-2">Gráficos (Em Breve)</h2>
           {/* Placeholder for Recharts */}
-          <div className="h-48 bg-gray-100 flex items-center justify-center rounded">
+          <div className="h-48 bg-gray-100 dark:bg-gray-700 flex items-center justify-center rounded">
             <p>Gráficos serão exibidos aqui</p>
           </div>
         </div>
       </div>
 
-      <div className="bg-white p-4 rounded shadow mb-8">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow mb-8">
         <h2 className="text-xl font-semibold mb-2">Progresso Orçamentário</h2>
         <ul>
           {calculatedBudgets.map(cb => {
             const spent = categoryExpenses[cb.categoryId] || 0
             return (
-              <li key={cb.id} className="py-2 border-b last:border-b-0">
+              <li key={cb.id} className="py-2 border-b border-gray-200 dark:border-gray-700 last:border-b-0">
                 <span>{cb.category.name}: Gastos {formatCurrency(spent)} de {formatCurrency(cb.budgetedAmount)}</span>
                 <div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
                   <div className="bg-blue-600 h-2.5 rounded-full" style={{ width: `${(spent / cb.budgetedAmount) * 100}%` }}></div>
@@ -89,7 +89,7 @@ export default async function DashboardPage() {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
-        <div className="bg-white p-4 rounded shadow">
+        <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
           <h2 className="text-xl font-semibold mb-2">Nova Operação</h2>
           <form action={async (formData) => {
             'use server'
@@ -97,27 +97,27 @@ export default async function DashboardPage() {
             revalidatePath('/dashboard')
           }} className="space-y-4">
             <div>
-              <label htmlFor="amount" className="block text-sm font-medium text-gray-700">Valor</label>
-              <input type="number" step="0.01" name="amount" id="amount" required className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
+              <label htmlFor="amount" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Valor</label>
+              <input type="number" step="0.01" name="amount" id="amount" required className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
             </div>
             <div>
-              <label htmlFor="type" className="block text-sm font-medium text-gray-700">Tipo</label>
-              <select name="type" id="type" required className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+              <label htmlFor="type" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Tipo</label>
+              <select name="type" id="type" required className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                 <option value="INCOME">Receita</option>
                 <option value="EXPENSE">Despesa</option>
               </select>
             </div>
             <div>
-              <label htmlFor="description" className="block text-sm font-medium text-gray-700">Descrição</label>
-              <input type="text" name="description" id="description" className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
+              <label htmlFor="description" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Descrição</label>
+              <input type="text" name="description" id="description" className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
             </div>
             <div>
-              <label htmlFor="date" className="block text-sm font-medium text-gray-700">Data</label>
-              <input type="date" name="date" id="date" defaultValue={new Date().toISOString().split('T')[0]} required className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
+              <label htmlFor="date" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Data</label>
+              <input type="date" name="date" id="date" defaultValue={new Date().toISOString().split('T')[0]} required className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
             </div>
             <div>
-              <label htmlFor="categoryId" className="block text-sm font-medium text-gray-700">Categoria</label>
-              <select name="categoryId" id="categoryId" className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
+              <label htmlFor="categoryId" className="block text-sm font-medium text-gray-700 dark:text-gray-300">Categoria</label>
+              <select name="categoryId" id="categoryId" className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
                 <option value="">Selecionar Categoria (Opcional)</option>
                 {categories.map(category => (
                   <option key={category.id} value={category.id}>{category.name}</option>
@@ -130,21 +130,21 @@ export default async function DashboardPage() {
           </form>
         </div>
 
-        <div className="bg-white p-4 rounded shadow">
+        <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
           <h2 className="text-xl font-semibold mb-2">Categorias</h2>
           <form action={async (formData) => {
             'use server'
             await createCategory(formData)
             revalidatePath('/dashboard')
           }} className="flex space-x-2 mb-4">
-            <input type="text" name="name" placeholder="Nome da Categoria" required className="flex-grow rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
+            <input type="text" name="name" placeholder="Nome da Categoria" required className="flex-grow rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" />
             <button type="submit" className="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500">
               Adicionar Categoria
             </button>
           </form>
           <ul>
             {categories.map(category => (
-              <li key={category.id} className="flex justify-between items-center py-2 border-b last:border-b-0">
+              <li key={category.id} className="flex justify-between items-center py-2 border-b border-gray-200 dark:border-gray-700 last:border-b-0">
                 <span>{category.name}</span>
                 <form action={async () => {
                   'use server'
@@ -159,9 +159,9 @@ export default async function DashboardPage() {
         </div>
       </div>
 
-      <div className="bg-white p-4 rounded shadow">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
         <h2 className="text-xl font-semibold mb-2">Operações</h2>
-        <ul className="divide-y divide-gray-200">
+        <ul className="divide-y divide-gray-200 dark:divide-gray-700">
           {operations.map(operation => (
             <li key={operation.id} className="py-4 flex justify-between items-center">
               <div>
@@ -170,9 +170,9 @@ export default async function DashboardPage() {
                   {operation.type === 'INCOME' ? '+' : '-'}{formatCurrency(operation.amount)}
                 </p>
                 {operation.category && (
-                  <p className="text-xs text-gray-500">Categoria: {operation.category.name}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">Categoria: {operation.category.name}</p>
                 )}
-                <p className="text-xs text-gray-500">{new Date(operation.date).toLocaleDateString()}</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">{new Date(operation.date).toLocaleDateString()}</p>
               </div>
               <form action={async () => {
                 'use server'

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,48 +1,76 @@
 @import "tailwindcss";
 
+@custom-variant dark (&:where(.dark, .dark *));
+
 :root {
-  --background: #f8fafc;
-  --foreground: #0f172a;
-  --primary: #3b82f6;
-  --primary-hover: #2563eb;
+  --background: 0 0% 100%;
+  --foreground: 222.2 84% 4.9%;
+  --card: 0 0% 100%;
+  --card-foreground: 222.2 84% 4.9%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222.2 84% 4.9%;
+  --primary: 222.2 47.4% 11.2%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 210 40% 96.1%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
+  --muted: 210 40% 96.1%;
+  --muted-foreground: 215.4 16.3% 46.9%;
+  --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 214.3 31.8% 91.4%;
+  --input: 214.3 31.8% 91.4%;
+  --ring: 222.2 84% 4.9%;
+  --radius: 0.5rem;
 }
 
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-/* Dark theme variables */
 .dark {
-  --background: #0f172a;
-  --foreground: #f8fafc;
-  --primary: #60a5fa;
-  --primary-hover: #3b82f6;
+  --background: 222.2 84% 4.9%;
+  --foreground: 210 40% 98%;
+  --card: 222.2 84% 4.9%;
+  --card-foreground: 210 40% 98%;
+  --popover: 222.2 84% 4.9%;
+  --popover-foreground: 210 40% 98%;
+  --primary: 210 40% 98%;
+  --primary-foreground: 222.2 47.4% 11.2%;
+  --secondary: 217.2 32.6% 17.5%;
+  --secondary-foreground: 210 40% 98%;
+  --muted: 217.2 32.6% 17.5%;
+  --muted-foreground: 215 20.2% 65.1%;
+  --accent: 217.2 32.6% 17.5%;
+  --accent-foreground: 210 40% 98%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 217.2 32.6% 17.5%;
+  --input: 217.2 32.6% 17.5%;
+  --ring: 212.7 26.8% 83.9%;
 }
 
-.light {
-  --background: #f8fafc;
-  --foreground: #0f172a;
-  --primary: #3b82f6;
-  --primary-hover: #2563eb;
+@theme {
+  --color-background: hsl(var(--background));
+  --color-foreground: hsl(var(--foreground));
+  --color-card: hsl(var(--card));
+  --color-card-foreground: hsl(var(--card-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
+  --color-primary: hsl(var(--primary));
+  --color-primary-foreground: hsl(var(--primary-foreground));
+  --color-secondary: hsl(var(--secondary));
+  --color-secondary-foreground: hsl(var(--secondary-foreground));
+  --color-muted: hsl(var(--muted));
+  --color-muted-foreground: hsl(var(--muted-foreground));
+  --color-accent: hsl(var(--accent));
+  --color-accent-foreground: hsl(var(--accent-foreground));
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-border: hsl(var(--border));
+  --color-input: hsl(var(--input));
+  --color-ring: hsl(var(--ring));
 }
 
 body {
-  background: linear-gradient(
-    160deg,
-    var(--background) 0%,
-    rgba(245, 245, 245, 0.8) 100%
-  );
-  color: var(--foreground);
-  font-family:
-    "Work Sans",
-    var(--font-sans),
-    system-ui,
-    -apple-system,
-    sans-serif;
-  line-height: 1.6;
-  min-height: 100vh;
-  padding: 2rem;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+  font-family: var(--font-sans);
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-import Link from 'next/link';
-import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { redirect } from "next/navigation";
+import { ThemeProvider } from "@/components/theme-provider";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -21,7 +23,7 @@ export const metadata: Metadata = {
 };
 
 async function getUser() {
-  'use server';
+  "use server";
   const supabase = await createClient();
   return await (await supabase).auth.getUser();
 }
@@ -31,42 +33,72 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const { data: { user } } = await getUser();
+  const {
+    data: { user },
+  } = await getUser();
 
   const signOut = async () => {
-    'use server';
+    "use server";
     const supabase = await createClient();
     await (await supabase).auth.signOut();
-    return redirect('/login');
+    return redirect("/login");
   };
 
   return (
-    <html lang="en">
+    <html lang="pt-BR" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-100`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <header className="bg-white shadow-sm py-4">
-          <nav className="container mx-auto flex justify-between items-center">
-            <Link href="/" className="text-xl font-bold text-gray-900">Meus Envelopes</Link>
-            <div className="flex items-center space-x-4">
-              {user ? (
-                <>
-                  <Link href="/dashboard" className="text-gray-600 hover:text-gray-900">Painel</Link>
-                  <Link href="/planning" className="text-gray-600 hover:text-gray-900">Planejamento</Link>
-                  <Link href="/shared-accounts" className="text-gray-600 hover:text-gray-900">Contas Compartilhadas</Link>
-                  <form action={signOut}>
-                    <button type="submit" className="text-red-600 hover:text-red-900">Sair</button>
-                  </form>
-                </>
-              ) : (
-                <Link href="/login" className="text-gray-600 hover:text-gray-900">Entrar</Link>
-              )}
-            </div>
-          </nav>
-        </header>
-        <main>
-          {children}
-        </main>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <header className="bg-card text-card-foreground shadow-sm py-4 sticky top-0 z-10">
+            <nav className="container mx-auto flex justify-between items-center">
+              <Link href="/" className="text-xl font-bold">
+                Meus Envelopes
+              </Link>
+              <div className="flex items-center space-x-4">
+                {user ? (
+                  <>
+                    <Link
+                      href="/dashboard"
+                      className="text-muted-foreground hover:text-foreground"
+                    >
+                      Painel
+                    </Link>
+                    <Link
+                      href="/planning"
+                      className="text-muted-foreground hover:text-foreground"
+                    >
+                      Planejamento
+                    </Link>
+                    <Link
+                      href="/shared-accounts"
+                      className="text-muted-foreground hover:text-foreground"
+                    >
+                      Contas Compartilhadas
+                    </Link>
+                    <form action={signOut}>
+                      <button
+                        type="submit"
+                        className="text-destructive hover:text-destructive/90"
+                      >
+                        Sair
+                      </button>
+                    </form>
+                  </>
+                ) : (
+                  <Link
+                    href="/login"
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    Entrar
+                  </Link>
+                )}
+                <ThemeToggle />
+              </div>
+            </nav>
+          </header>
+          <main>{children}</main>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,20 +1,25 @@
-'use client'
+"use client";
 
-import { useTheme } from '@/components/theme-provider'
-import { Button } from '@/components/ui/button'
-import { Moon, Sun } from 'phosphor-react'
+import { Moon, Sun } from "phosphor-react";
+import { useTheme } from "@/components/theme-provider";
+import { Button } from "@/components/ui/button";
 
 export function ThemeToggle() {
-  const { theme, toggleTheme } = useTheme()
+  const { setTheme, resolvedTheme } = useTheme();
 
   return (
     <Button
+      type="button"
       variant="outline"
       size="icon"
-      onClick={toggleTheme}
-      className="rounded-full"
+      onClick={() => setTheme(resolvedTheme === "light" ? "dark" : "light")}
     >
-      {theme === 'light' ? <Moon size={20} /> : <Sun size={20} />}
+      {resolvedTheme === "dark" ? (
+        <Sun className="h-[1.2rem] w-[1.2rem]" />
+      ) : (
+        <Moon className="h-[1.2rem] w-[1.2rem]" />
+      )}
+      <span className="sr-only">Toggle theme</span>
     </Button>
-  )
+  );
 }


### PR DESCRIPTION
This commit introduces a theme toggle, allowing users to switch between light, dark, and system default modes.

It leverages the `next-themes` library for theme management. The implementation includes:
- A new `ThemeProvider` component wrapping the root layout.
- A `ThemeToggle` component in the header for user interaction.
- Refactoring `globals.css` to use CSS variables for colors, enabling dynamic theme switching.
- Applying `dark:` utility classes to components, particularly on the dashboard page, to ensure they adapt to the selected theme.

Additionally, the `build` script in `package.json` is updated to run `prisma generate` before the build process.