### PR TITLE
Refactor CurrencyInput for improved typing and structure

### DIFF
--- a/src/components/ui/currency-input.tsx
+++ b/src/components/ui/currency-input.tsx
@@ -1,25 +1,28 @@
-'use client'
+import { ChangeEvent, forwardRef, InputHTMLAttributes } from "react";
 
-import * as React from 'react'
-import { formatCurrency, parseCurrency } from '@/lib/currency'
-import { Input, InputProps } from '@/components/ui/input'
+import { formatCurrency, parseCurrency } from "@/lib/currency";
+import { Input } from "@/components/ui/input";
 
-const CurrencyInput = React.forwardRef<HTMLInputElement, InputProps>(
+interface CurrencyInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+}
+
+const CurrencyInput = forwardRef<HTMLInputElement, CurrencyInputProps>(
   ({ onChange, ...props }, ref) => {
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-      const { value } = e.target
-      const parsedValue = parseCurrency(value)
-      e.target.value = formatCurrency(parsedValue)
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+      const { value } = e.target;
+      const parsedValue = parseCurrency(value);
+      e.target.value = formatCurrency(parsedValue);
 
       if (onChange) {
-        onChange(e)
+        onChange(e);
       }
-    }
+    };
 
-    return <Input {...props} onChange={handleChange} ref={ref} />
-  },
-)
+    return <Input {...props} onChange={handleChange} ref={ref} />;
+  }
+);
 
-CurrencyInput.displayName = 'CurrencyInput'
+CurrencyInput.displayName = "CurrencyInput";
 
-export { CurrencyInput }
+export { CurrencyInput };


### PR DESCRIPTION
Refactors the `CurrencyInput` component to use `forwardRef` directly from React and define a specific `CurrencyInputProps` interface. This improves type safety and component structure.